### PR TITLE
Move TSDB version into ARG within Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
+ARG TSDB_VERSION_TAG
 ARG PG_VERSION_TAG
-FROM timescale/timescaledb:1.3.2-${PG_VERSION_TAG}
+FROM timescale/timescaledb:${TSDB_VERSION_TAG}-${PG_VERSION_TAG}
 
 MAINTAINER Timescale https://www.timescale.com
 


### PR DESCRIPTION
Migrated TSDB version into ARG to facilitate TSDB version configuration at build time